### PR TITLE
Fix issue with camera error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-pdf417 ChangeLog
 
+## 4.0.1 - 2022-03-30
+
+### Fixed
+- Fixed issue with camera error.
+
 ## 4.0.0 - 2022-03-30
 
 ### Changed

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -162,7 +162,7 @@ export default {
       this.currentCamera = await this.scanner.getCurrentCamera();
     } catch(e) {
       console.error(e);
-      this.$emit('error', e.message);
+      this.cameraError = true;
     }
   },
   async beforeDestroy() {


### PR DESCRIPTION
Camera errors are now thrown later so they need to be handled internally and not emitted up. This is another discovered v9 change.