### PR TITLE
Fix tip text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-pdf417 ChangeLog
 
+## 4.0.2 - TBD
+
+### Fixed
+- Fix issue with tip text being offset on mobile.
+
 ## 4.0.1 - 2022-03-30
 
 ### Fixed

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -38,15 +38,16 @@
       </div>
       <!-- Video Stream -->
       <div class="dce-video-container" />
-      <!-- Tip Text -->
-      <div
-        v-if="!loadingCamera && !scanning"
-        ref="tipText"
-        class="text-white"
-        style="position: absolute;"
-        :style="`bottom: calc(${regionTop}% - 30px)`">
-        {{tipText}}
-      </div>
+    </div>
+
+    <!-- Tip Text -->
+    <div
+      v-if="!cameraError && !loadingCamera && !scanning"
+      ref="tipText"
+      class="text-white text-center"
+      style="position: absolute;"
+      :style="`bottom: calc(${regionTop}% - 30px)`">
+      {{tipText}}
     </div>
 
     <!-- Close -->


### PR DESCRIPTION
For some reason v9 introduced some sort of offset to our tip text. I believe this is related to the inject video element. I move the tip text to a high level to solve the problem.