### PR TITLE
Fix `getDLInfo` API call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-pdf417 ChangeLog
 
+## 8.1.1 - 2023-06-xx
+
+### Fixed
+- Fix `getDLInfo` API call.
+
 ## 8.1.0 - 2023-06-15
 
 ### Added

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -207,7 +207,7 @@ export default {
         });
 
         this.scanner.onUniqueRead = txt => {
-          this.$emit('result', this.getDLInfo(txt));
+          this.$emit('result', this.getDLInfo({txt}));
         };
 
         this.scanner.dce.regionMaskStrokeStyle = this.guideColor;


### PR DESCRIPTION
The API signature for `getDLInfo` was changed in this commit, but the API call in this PR was not updated to use the new signature.

https://github.com/digitalbazaar/bedrock-vue-pdf417/commit/d9d3472eff2654fd264b48a071135cbed33d28de