### PR TITLE
Fix component name (typo).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-pdf417 ChangeLog
 
+## 9.0.1 - 2024-07-dd
+
+### Fixed
+- Update component name typo in template.
+
 ## 9.0.0 - 2024-03-14
 
 ### Changed

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -33,7 +33,7 @@
         <slot
           v-if="scanning"
           name="scannerSpinner">
-          <Spinner />
+          <BcsSpinner />
         </slot>
       </div>
       <!-- Video Stream -->


### PR DESCRIPTION
#### _Resolves - bug fix for component name in template_

---

### What kind of change does this PR introduce?

- Bug fix.

<br/>

### What is the current behavior?

- Component is named 'Spinner' which is not present in file.

<br/>

### What is the new behavior?

- Update component name to 'BcsSpinner', which is a spinner component imported in file.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<br/>

### How has this been tested?

- Has not been tested, this PR was initiated by using this library and receiving a console warning:
```
runtime-core.esm-bundler.js:191 [Vue warn]: Failed to resolve component: Spinner
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
```
