### PR TITLE
Hide upload button

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,8 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-pdf417 ChangeLog
 
+## 9.1.0 - 2024-07-xx
+
+### Added
+- Add property `hideUploadButton` to hide camera's upload image button.
+
 ## 9.0.1 - 2024-07-17
 
 ### Fixed

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -105,7 +105,7 @@ export default {
     },
     hideUploadButton: {
       type: Boolean,
-      default: undefined
+      default: false
     }
   },
   emits: [

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -65,6 +65,7 @@
       @click="close()" />
     <!-- Buttons -->
     <BcsButtons
+      :hideUploadButton="hideUploadButton"
       :loading-camera="loadingCamera"
       :scanning="scanning"
       :camera-list="cameraList"
@@ -101,6 +102,10 @@ export default {
     guideColor: {
       type: String,
       default: 'rgb(254, 142, 20)'
+    },
+    hideUploadButton: {
+      type: Boolean,
+      default: undefined
     }
   },
   emits: [

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -65,7 +65,7 @@
       @click="close()" />
     <!-- Buttons -->
     <BcsButtons
-      :hideUploadButton="hideUploadButton"
+      :hide-upload-button="hideUploadButton"
       :loading-camera="loadingCamera"
       :scanning="scanning"
       :camera-list="cameraList"

--- a/components/BcsButtons.vue
+++ b/components/BcsButtons.vue
@@ -28,12 +28,14 @@
     </q-btn-dropdown>
     <!-- Upload Button -->
     <input
+      v-if="!hideUploadButton"
       ref="uploadImage"
       type="file"
       accept="image/png,image/jpeg,image/bmp,image/gif"
       style="display: none"
       @change="upload($event)">
     <q-btn
+      v-if="!hideUploadButton"
       flat
       no-caps
       text-color="white"
@@ -58,6 +60,10 @@ export default {
       default: undefined
     },
     loadingCamera: {
+      type: Boolean,
+      default: undefined
+    },
+    hideUploadButton: {
       type: Boolean,
       default: undefined
     },

--- a/components/BcsButtons.vue
+++ b/components/BcsButtons.vue
@@ -65,7 +65,7 @@ export default {
     },
     hideUploadButton: {
       type: Boolean,
-      default: undefined
+      default: false
     },
     scanning: {
       type: Boolean,


### PR DESCRIPTION
#### _Resolves - offers ability to hide `Upload` image button_

---

### What kind of change does this PR introduce?

- UI customization.

<br/>

### What is the current behavior?

- Camera and Upload button are always present.

<br/>

### What is the new behavior?

- Upload button can be hidden with a prop.

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Symlinked and locally rendered.

<br/>

### Screenshots: n/a